### PR TITLE
Add rotation support for galaxy map points

### DIFF
--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -905,13 +905,20 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
     rotatingPointRef.current = rotatingPoint;
   }, [rotatingPoint]);
 
-  // Tecla Esc para sair do modo de redimensionamento
+  // Tecla Esc para sair dos modos de edição
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape" && resizingPointRef.current !== null) {
-        setResizingPoint(null);
-        setResizeStartScale(1);
-        setResizeStartY(0);
+      if (e.key === "Escape") {
+        if (resizingPointRef.current !== null) {
+          setResizingPoint(null);
+          setResizeStartScale(1);
+          setResizeStartY(0);
+        }
+        if (rotatingPointRef.current !== null) {
+          setRotatingPoint(null);
+          setRotateStartRotation(0);
+          setRotateStartAngle(0);
+        }
       }
     };
 

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -1013,7 +1013,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
     [],
   );
 
-  // Função para atualizar direção do auto-piloto baseada na posição do mouse
+  // Função para atualizar dire��ão do auto-piloto baseada na posição do mouse
   const updateAutoPilotDirection = useCallback(
     (mouseX: number, mouseY: number) => {
       const canvas = canvasRef.current;
@@ -2291,16 +2291,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
     e.stopPropagation();
 
     // Check if holding Ctrl for resize mode
-    console.log("🔧 handlePointMouseDown:", {
-      ctrlKey: e.ctrlKey,
-      isCtrlPressed,
-      pointId: point.id,
-    });
     if (e.ctrlKey) {
-      console.log(
-        "🔧 Ativando modo de redimensionamento para ponto:",
-        point.id,
-      );
       setResizingPoint(point.id);
       setResizeStartScale(point.scale || 1);
       setResizeStartY(e.clientY);
@@ -2905,7 +2896,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
                         Área de Interação
                       </p>
                       <p className="text-xs text-gray-500">
-                        Comércio • Missões ��� Informações
+                        Comércio • Missões • Informações
                       </p>
                     </div>
                   </div>

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -895,6 +895,13 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
         console.log("🔧 Ctrl pressionado, ativando modo redimensionar");
         setIsCtrlPressed(true);
       }
+      // Tecla Esc para sair do modo de redimensionamento
+      if (e.key === "Escape" && resizingPoint !== null) {
+        console.log("🔧 Esc pressionado, saindo do modo redimensionar");
+        setResizingPoint(null);
+        setResizeStartScale(1);
+        setResizeStartY(0);
+      }
     };
 
     const handleKeyUp = (e: KeyboardEvent) => {

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -235,6 +235,9 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
   const [resizingPoint, setResizingPoint] = useState<number | null>(null);
   const [resizeStartScale, setResizeStartScale] = useState<number>(1);
   const [resizeStartY, setResizeStartY] = useState<number>(0);
+  const [rotatingPoint, setRotatingPoint] = useState<number | null>(null);
+  const [rotateStartRotation, setRotateStartRotation] = useState<number>(0);
+  const [rotateStartAngle, setRotateStartAngle] = useState<number>(0);
   const [isDragging, setIsDragging] = useState(false);
 
   // Ref para acessar estado atual nos event listeners

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -1344,8 +1344,13 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
       return;
     }
 
-    // Não inicia drag do mapa se estiver arrastando um ponto ou redimensionando
-    if (draggingPoint !== null || resizingPoint !== null) return;
+    // Não inicia drag do mapa se estiver arrastando um ponto, redimensionando ou rotacionando
+    if (
+      draggingPoint !== null ||
+      resizingPoint !== null ||
+      rotatingPoint !== null
+    )
+      return;
 
     setIsDragging(true);
     setHasMoved(false);

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -535,7 +535,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
         const opacity = Math.min(1, (star.life / star.maxLife) * 1.2); // Mais luminosas
         const timeDelta = (currentTime - star.startTime) * 0.001;
 
-        // Animaç��o de tamanho baseada em seno
+        // Animaç����o de tamanho baseada em seno
         const sizeVariation = 1 + Math.sin(timeDelta * 8) * 0.3; // Pulso mais intenso
         const currentSize = star.size * sizeVariation;
 
@@ -892,12 +892,10 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === "Control" || e.ctrlKey) {
-        console.log("🔧 Ctrl pressionado, ativando modo redimensionar");
         setIsCtrlPressed(true);
       }
       // Tecla Esc para sair do modo de redimensionamento
       if (e.key === "Escape" && resizingPoint !== null) {
-        console.log("🔧 Esc pressionado, saindo do modo redimensionar");
         setResizingPoint(null);
         setResizeStartScale(1);
         setResizeStartY(0);
@@ -906,7 +904,6 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
 
     const handleKeyUp = (e: KeyboardEvent) => {
       if (e.key === "Control" || !e.ctrlKey) {
-        console.log("🔧 Ctrl solto, desativando modo redimensionar");
         setIsCtrlPressed(false);
         // Sair do modo de redimensionamento quando Ctrl for solto
         if (resizingPoint !== null) {
@@ -2203,7 +2200,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
         0,
         Math.min(1, distance / maxDistance),
       );
-      const volume = (1 - normalizedDistance) * 0.5; // Volume máximo aumentado para 0.5
+      const volume = (1 - normalizedDistance) * 0.5; // Volume m��ximo aumentado para 0.5
 
       if (!merchantEngineSound) {
         // Cria um som de motor diferente para a nave mercante

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -45,9 +45,10 @@ const galaxyWorldToPoint = (world: GalaxyWorld): Point => ({
   image: world.imageUrl,
   type: "world",
   scale: world.scale,
+  rotation: world.rotation || 0,
 });
 
-// 7 pontos distribuídos em c����rculo ao redor do centro
+// 7 pontos distribuídos em c��rculo ao redor do centro
 const createDefaultPoints = (): Point[] => {
   const centerX = 50;
   const centerY = 50;

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -2820,13 +2820,15 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
                         : "hover:scale-105 hover:brightness-110"
                   }`}
                   style={{
-                    transform: `scale(${point.scale || 1})`,
+                    transform: `scale(${point.scale || 1}) rotate(${point.rotation || 0}deg)`,
                     filter:
                       draggingPoint === point.id
                         ? "drop-shadow(0 0 20px rgba(255, 255, 0, 0.8)) drop-shadow(0 8px 25px rgba(0, 0, 0, 0.4))"
                         : resizingPoint === point.id
                           ? "drop-shadow(0 0 25px rgba(0, 255, 255, 0.8)) drop-shadow(0 8px 25px rgba(0, 0, 0, 0.4))"
-                          : "drop-shadow(0 8px 25px rgba(0, 0, 0, 0.4)) drop-shadow(0 4px 12px rgba(0, 0, 0, 0.2)) drop-shadow(0 0 15px rgba(255, 255, 255, 0.1))",
+                          : rotatingPoint === point.id
+                            ? "drop-shadow(0 0 25px rgba(255, 0, 255, 0.8)) drop-shadow(0 8px 25px rgba(0, 0, 0, 0.4))"
+                            : "drop-shadow(0 8px 25px rgba(0, 0, 0, 0.4)) drop-shadow(0 4px 12px rgba(0, 0, 0, 0.2)) drop-shadow(0 0 15px rgba(255, 255, 255, 0.1))",
                   }}
                 >
                   <img

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -2017,7 +2017,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
       );
     };
 
-    if (isDragging || draggingPoint !== null) {
+    if (isDragging || draggingPoint !== null || rotatingPoint !== null) {
       document.addEventListener("mousemove", handleGlobalMouseMove);
       document.addEventListener("mouseup", handleGlobalMouseUp);
       document.addEventListener("touchmove", handleGlobalTouchMove, {

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -78,7 +78,7 @@ const createDefaultPoints = (): Point[] => {
         "https://cdn.builder.io/api/v1/image/assets%2F676198b3123e49d5b76d7e142e1266eb%2F02782c34d2cd4353a884ab021ce35173?format=webp&width=1600",
     },
     {
-      label: "Dimensão Alienígena",
+      label: "Dimens��o Alienígena",
       type: "alien",
       image:
         "https://cdn.builder.io/api/v1/image/assets%2F676198b3123e49d5b76d7e142e1266eb%2Facb3e8e8eb33422a88b01594f5d1c470?format=webp&width=1600",
@@ -1344,6 +1344,14 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
   const handleMouseDown = (e: React.MouseEvent) => {
     if (isAutoPilot) {
       setIsAutoPilot(false);
+      return;
+    }
+
+    // Sair do modo de redimensionamento ao clicar no canvas
+    if (resizingPoint !== null) {
+      setResizingPoint(null);
+      setResizeStartScale(1);
+      setResizeStartY(0);
       return;
     }
 

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -1375,8 +1375,13 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
       return;
     }
 
-    // Não inicia drag do mapa se estiver arrastando um ponto ou redimensionando
-    if (draggingPoint !== null || resizingPoint !== null) return;
+    // Não inicia drag do mapa se estiver arrastando um ponto, redimensionando ou rotacionando
+    if (
+      draggingPoint !== null ||
+      resizingPoint !== null ||
+      rotatingPoint !== null
+    )
+      return;
 
     const touch = e.touches[0];
     if (!touch) return;

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -240,8 +240,9 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
   const [rotateStartAngle, setRotateStartAngle] = useState<number>(0);
   const [isDragging, setIsDragging] = useState(false);
 
-  // Ref para acessar estado atual nos event listeners
+  // Refs para acessar estados atuais nos event listeners
   const resizingPointRef = useRef<number | null>(null);
+  const rotatingPointRef = useRef<number | null>(null);
   const [isColliding, setIsColliding] = useState(false);
   const [collisionNotification, setCollisionNotification] = useState<{
     show: boolean;

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -888,6 +888,47 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
     };
   }, [shipRotation]);
 
+  // Controle da tecla Ctrl para modo de redimensionamento
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Control" || e.ctrlKey) {
+        setIsCtrlPressed(true);
+      }
+    };
+
+    const handleKeyUp = (e: KeyboardEvent) => {
+      if (e.key === "Control" || !e.ctrlKey) {
+        setIsCtrlPressed(false);
+        // Sair do modo de redimensionamento quando Ctrl for solto
+        if (resizingPoint !== null) {
+          setResizingPoint(null);
+          setResizeStartScale(1);
+          setResizeStartY(0);
+        }
+      }
+    };
+
+    // Também detecta quando a janela perde foco (Alt+Tab, etc)
+    const handleWindowBlur = () => {
+      setIsCtrlPressed(false);
+      if (resizingPoint !== null) {
+        setResizingPoint(null);
+        setResizeStartScale(1);
+        setResizeStartY(0);
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    document.addEventListener("keyup", handleKeyUp);
+    window.addEventListener("blur", handleWindowBlur);
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      document.removeEventListener("keyup", handleKeyUp);
+      window.removeEventListener("blur", handleWindowBlur);
+    };
+  }, [resizingPoint]);
+
   // Função para repelir o jogador
   const repelPlayer = useCallback(
     (collisionX: number, collisionY: number) => {

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -33,6 +33,7 @@ interface Point {
   image: string;
   type: string;
   scale?: number;
+  rotation?: number;
 }
 
 // Converter GalaxyWorld para Point
@@ -46,7 +47,7 @@ const galaxyWorldToPoint = (world: GalaxyWorld): Point => ({
   scale: world.scale,
 });
 
-// 7 pontos distribuídos em c��rculo ao redor do centro
+// 7 pontos distribuídos em c����rculo ao redor do centro
 const createDefaultPoints = (): Point[] => {
   const centerX = 50;
   const centerY = 50;

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -1839,6 +1839,35 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
         return;
       }
 
+      // Handle point rotation
+      if (isAdmin && rotatingPoint !== null) {
+        const rect = containerRef.current?.getBoundingClientRect();
+        if (!rect) return;
+
+        const point = points.find((p) => p.id === rotatingPoint);
+        if (!point) return;
+
+        const centerX = (point.x / 100) * rect.width;
+        const centerY = (point.y / 100) * rect.height;
+        const touchX = touch.clientX - rect.left;
+        const touchY = touch.clientY - rect.top;
+
+        const currentAngle =
+          Math.atan2(touchY - centerY, touchX - centerX) * (180 / Math.PI);
+        const angleDelta = currentAngle - rotateStartAngle;
+        let newRotation = (rotateStartRotation + angleDelta) % 360;
+
+        // Normalize to 0-360 range
+        if (newRotation < 0) newRotation += 360;
+
+        const newPoints = points.map((p) =>
+          p.id === rotatingPoint ? { ...p, rotation: newRotation } : p,
+        );
+
+        setPoints(newPoints);
+        return;
+      }
+
       // Handle point dragging
       if (isAdmin && draggingPoint !== null) {
         const rect = containerRef.current?.getBoundingClientRect();

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -2315,6 +2315,25 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
       return;
     }
 
+    // Check if holding Alt for rotation mode
+    if (e.altKey) {
+      const rect = containerRef.current?.getBoundingClientRect();
+      if (!rect) return;
+
+      const centerX = (point.x / 100) * rect.width;
+      const centerY = (point.y / 100) * rect.height;
+      const mouseX = e.clientX - rect.left;
+      const mouseY = e.clientY - rect.top;
+
+      const startAngle =
+        Math.atan2(mouseY - centerY, mouseX - centerX) * (180 / Math.PI);
+
+      setRotatingPoint(point.id);
+      setRotateStartRotation(point.rotation || 0);
+      setRotateStartAngle(startAngle);
+      return;
+    }
+
     const rect = containerRef.current?.getBoundingClientRect();
     if (!rect) return;
 

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -1251,7 +1251,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
     showCollisionNotification,
   ]);
 
-  // Fun��ão para calcular distância toroidal correta
+  // Função para calcular distância toroidal correta
   const getToroidalDistance = (
     pos1: { x: number; y: number },
     pos2: { x: number; y: number },
@@ -2723,7 +2723,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
                     }}
                     onError={(e) => {
                       console.error(
-                        `❌ Erro ao carregar imagem: ${point.label}`,
+                        `�� Erro ao carregar imagem: ${point.label}`,
                         point.image,
                       );
                     }}
@@ -2923,7 +2923,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
               </span>
             </div>
             <div className="text-xs text-blue-100 mt-1">
-              Solte Ctrl ou pressione Esc para sair
+              Pressione Esc para sair
             </div>
           </motion.div>
         </div>

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -235,6 +235,10 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
   const [resizeStartY, setResizeStartY] = useState<number>(0);
   const [isCtrlPressed, setIsCtrlPressed] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
+
+  // Refs para acessar estados atuais nos event listeners
+  const resizingPointRef = useRef<number | null>(null);
+  const isCtrlPressedRef = useRef<boolean>(false);
   const [isColliding, setIsColliding] = useState(false);
   const [collisionNotification, setCollisionNotification] = useState<{
     show: boolean;
@@ -276,7 +280,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
   const mapRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  // Motion values para posi��ão do mapa (movimento inverso da nave)
+  // Motion values para posi����o do mapa (movimento inverso da nave)
   const getInitialMapPosition = () => {
     const saved = localStorage.getItem("xenopets-player-data");
     const data = saved
@@ -1039,7 +1043,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
     [],
   );
 
-  // Função para atualizar direção do auto-piloto baseada na posição do mouse
+  // Função para atualizar direç��o do auto-piloto baseada na posição do mouse
   const updateAutoPilotDirection = useCallback(
     (mouseX: number, mouseY: number) => {
       const canvas = canvasRef.current;
@@ -2282,7 +2286,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
       } else {
         // Atualiza volume do som existente com suavidade
         merchantEngineSound.setVolume(volume);
-        console.log(`🔊 Volume atualizado: ${volume.toFixed(3)}`);
+        console.log(`��� Volume atualizado: ${volume.toFixed(3)}`);
       }
     } else {
       // Para o som se existir

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -2329,7 +2329,16 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
     e.stopPropagation();
 
     // Check if holding Ctrl for resize mode
+    console.log("🔧 handlePointMouseDown:", {
+      ctrlKey: e.ctrlKey,
+      isCtrlPressed,
+      pointId: point.id,
+    });
     if (e.ctrlKey || isCtrlPressed) {
+      console.log(
+        "🔧 Ativando modo de redimensionamento para ponto:",
+        point.id,
+      );
       setResizingPoint(point.id);
       setResizeStartScale(point.scale || 1);
       setResizeStartY(e.clientY);

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -901,6 +901,10 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
     resizingPointRef.current = resizingPoint;
   }, [resizingPoint]);
 
+  useEffect(() => {
+    rotatingPointRef.current = rotatingPoint;
+  }, [rotatingPoint]);
+
   // Tecla Esc para sair do modo de redimensionamento
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -1638,6 +1638,35 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
         return;
       }
 
+      // Handle point rotation
+      if (isAdmin && rotatingPoint !== null) {
+        const rect = containerRef.current?.getBoundingClientRect();
+        if (!rect) return;
+
+        const point = points.find((p) => p.id === rotatingPoint);
+        if (!point) return;
+
+        const centerX = (point.x / 100) * rect.width;
+        const centerY = (point.y / 100) * rect.height;
+        const mouseX = e.clientX - rect.left;
+        const mouseY = e.clientY - rect.top;
+
+        const currentAngle =
+          Math.atan2(mouseY - centerY, mouseX - centerX) * (180 / Math.PI);
+        const angleDelta = currentAngle - rotateStartAngle;
+        let newRotation = (rotateStartRotation + angleDelta) % 360;
+
+        // Normalize to 0-360 range
+        if (newRotation < 0) newRotation += 360;
+
+        const newPoints = points.map((p) =>
+          p.id === rotatingPoint ? { ...p, rotation: newRotation } : p,
+        );
+
+        setPoints(newPoints);
+        return;
+      }
+
       // Handle point dragging
       if (isAdmin && draggingPoint !== null) {
         const rect = containerRef.current?.getBoundingClientRect();

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -1381,6 +1381,14 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
       return;
     }
 
+    // Sair do modo de redimensionamento ao tocar no canvas
+    if (resizingPoint !== null) {
+      setResizingPoint(null);
+      setResizeStartScale(1);
+      setResizeStartY(0);
+      return;
+    }
+
     // Não inicia drag do mapa se estiver arrastando um ponto
     if (draggingPoint !== null) return;
 

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -904,11 +904,21 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
   // Controle da tecla Ctrl para modo de redimensionamento
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
+      console.log(
+        "🔧 handleKeyDown:",
+        e.key,
+        "ctrlKey:",
+        e.ctrlKey,
+        "current isCtrlPressed:",
+        isCtrlPressedRef.current,
+      );
       if (e.key === "Control" || e.ctrlKey) {
+        console.log("🔧 Setting isCtrlPressed to true");
         setIsCtrlPressed(true);
       }
       // Tecla Esc para sair do modo de redimensionamento
       if (e.key === "Escape" && resizingPointRef.current !== null) {
+        console.log("🔧 Esc pressed, exiting resize mode");
         setResizingPoint(null);
         setResizeStartScale(1);
         setResizeStartY(0);
@@ -916,10 +926,20 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
     };
 
     const handleKeyUp = (e: KeyboardEvent) => {
+      console.log(
+        "🔧 handleKeyUp:",
+        e.key,
+        "ctrlKey:",
+        e.ctrlKey,
+        "current resizingPoint:",
+        resizingPointRef.current,
+      );
       if (e.key === "Control" || !e.ctrlKey) {
+        console.log("🔧 Setting isCtrlPressed to false");
         setIsCtrlPressed(false);
         // Sair do modo de redimensionamento quando Ctrl for solto
         if (resizingPointRef.current !== null) {
+          console.log("🔧 Ctrl released, exiting resize mode");
           setResizingPoint(null);
           setResizeStartScale(1);
           setResizeStartY(0);

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -1349,16 +1349,8 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
       return;
     }
 
-    // Sair do modo de redimensionamento ao clicar no canvas
-    if (resizingPoint !== null) {
-      setResizingPoint(null);
-      setResizeStartScale(1);
-      setResizeStartY(0);
-      return;
-    }
-
-    // Não inicia drag do mapa se estiver arrastando um ponto
-    if (draggingPoint !== null) return;
+    // Não inicia drag do mapa se estiver arrastando um ponto ou redimensionando
+    if (draggingPoint !== null || resizingPoint !== null) return;
 
     setIsDragging(true);
     setHasMoved(false);

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -280,7 +280,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
   const mapRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  // Motion values para posi����o do mapa (movimento inverso da nave)
+  // Motion values para posi��ão do mapa (movimento inverso da nave)
   const getInitialMapPosition = () => {
     const saved = localStorage.getItem("xenopets-player-data");
     const data = saved
@@ -892,6 +892,15 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
     };
   }, [shipRotation]);
 
+  // Sincronizar refs com estados
+  useEffect(() => {
+    resizingPointRef.current = resizingPoint;
+  }, [resizingPoint]);
+
+  useEffect(() => {
+    isCtrlPressedRef.current = isCtrlPressed;
+  }, [isCtrlPressed]);
+
   // Controle da tecla Ctrl para modo de redimensionamento
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -1043,7 +1052,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
     [],
   );
 
-  // Função para atualizar direç��o do auto-piloto baseada na posição do mouse
+  // Função para atualizar direção do auto-piloto baseada na posição do mouse
   const updateAutoPilotDirection = useCallback(
     (mouseX: number, mouseY: number) => {
       const canvas = canvasRef.current;
@@ -1538,7 +1547,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
       WORLD_CONFIG.height,
     );
 
-    // Sistema de detecç��o de colisão
+    // Sistema de detecç���o de colisão
     const collision = checkCollisionWithBarriers(proposedX, proposedY);
     const allowMovement = !collision.isColliding;
 
@@ -2286,7 +2295,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
       } else {
         // Atualiza volume do som existente com suavidade
         merchantEngineSound.setVolume(volume);
-        console.log(`��� Volume atualizado: ${volume.toFixed(3)}`);
+        console.log(`🔊 Volume atualizado: ${volume.toFixed(3)}`);
       }
     } else {
       // Para o som se existir

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -233,12 +233,10 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
   const [resizingPoint, setResizingPoint] = useState<number | null>(null);
   const [resizeStartScale, setResizeStartScale] = useState<number>(1);
   const [resizeStartY, setResizeStartY] = useState<number>(0);
-  const [isCtrlPressed, setIsCtrlPressed] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
 
-  // Refs para acessar estados atuais nos event listeners
+  // Ref para acessar estado atual nos event listeners
   const resizingPointRef = useRef<number | null>(null);
-  const isCtrlPressedRef = useRef<boolean>(false);
   const [isColliding, setIsColliding] = useState(false);
   const [collisionNotification, setCollisionNotification] = useState<{
     show: boolean;

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -2043,6 +2043,9 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
     showCollisionNotification,
     draggingPoint,
     dragOffset,
+    rotatingPoint,
+    rotateStartRotation,
+    rotateStartAngle,
     points,
     isAdmin,
   ]);

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -2872,6 +2872,11 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
                       Escala: {point.scale.toFixed(1)}x
                     </div>
                   )}
+                  {point.rotation && point.rotation !== 0 && (
+                    <div className="text-purple-300 text-xs">
+                      Rotação: {point.rotation.toFixed(0)}°
+                    </div>
+                  )}
                   {isAdmin && (
                     <div className="text-yellow-400 text-xs mt-1">
                       <div>�� Arraste para mover</div>

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -1285,7 +1285,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
     return Math.sqrt(minDx * minDx + minDy * minDy);
   };
 
-  // Salva posição - simples
+  // Salva posi��ão - simples
   useEffect(() => {
     const interval = setInterval(() => {
       if (!isDragging && !isAutoPilot) {
@@ -2881,6 +2881,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
                     <div className="text-yellow-400 text-xs mt-1">
                       <div>�� Arraste para mover</div>
                       <div>🔧 Ctrl+Arraste para redimensionar</div>
+                      <div>🔄 Alt+Arraste para rotacionar</div>
                     </div>
                   )}
 

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -943,7 +943,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
       );
 
       if (distance > 0) {
-        // Normaliza a direç���o e aplica força de repulsão
+        // Normaliza a direç���o e aplica força de repuls��o
         const normalizedX = repelDirectionX / distance;
         const normalizedY = repelDirectionY / distance;
         const repelForce = 15; // For��a da repulsão
@@ -3048,6 +3048,26 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
               </span>
             </div>
             <div className="text-xs text-blue-100 mt-1">
+              Pressione Esc para sair
+            </div>
+          </motion.div>
+        </div>
+      )}
+
+      {/* Notificação do modo de rotação ativo */}
+      {rotatingPoint !== null && (
+        <div className="absolute top-4 left-1/2 transform -translate-x-1/2 z-50">
+          <motion.div
+            className="bg-purple-600 text-white px-4 py-2 rounded-lg shadow-lg border border-purple-400"
+            initial={{ opacity: 0, y: -20, scale: 0.9 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: -20, scale: 0.9 }}
+          >
+            <div className="flex items-center space-x-2">
+              <div className="w-2 h-2 bg-white rounded-full animate-pulse"></div>
+              <span className="text-sm font-medium">🔄 Modo Rotação Ativo</span>
+            </div>
+            <div className="text-xs text-purple-100 mt-1">
               Pressione Esc para sair
             </div>
           </motion.div>

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -2768,9 +2768,11 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
                 isAdmin
                   ? resizingPoint === point.id
                     ? "cursor-crosshair"
-                    : "cursor-grab hover:cursor-grab active:cursor-grabbing"
+                    : rotatingPoint === point.id
+                      ? "cursor-alias"
+                      : "cursor-grab hover:cursor-grab active:cursor-grabbing"
                   : "cursor-pointer"
-              } ${draggingPoint === point.id || resizingPoint === point.id ? "z-50" : "z-30"}`}
+              } ${draggingPoint === point.id || resizingPoint === point.id || rotatingPoint === point.id ? "z-50" : "z-30"}`}
               style={{
                 left: `${point.x}%`,
                 top: `${point.y}%`,

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -1980,6 +1980,15 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
         return;
       }
 
+      // Handle point rotation end
+      if (isAdmin && rotatingPoint !== null) {
+        await savePoints(points);
+        setRotatingPoint(null);
+        setRotateStartRotation(0);
+        setRotateStartAngle(0);
+        return;
+      }
+
       // Handle point dragging end
       if (isAdmin && draggingPoint !== null) {
         await savePoints(points);

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -2671,9 +2671,11 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
               key={point.id}
               className={`absolute transform -translate-x-1/2 -translate-y-1/2 ${
                 isAdmin
-                  ? "cursor-grab hover:cursor-grab active:cursor-grabbing"
+                  ? isCtrlPressed || resizingPoint === point.id
+                    ? "cursor-crosshair"
+                    : "cursor-grab hover:cursor-grab active:cursor-grabbing"
                   : "cursor-pointer"
-              } ${draggingPoint === point.id ? "z-50" : "z-30"}`}
+              } ${draggingPoint === point.id || resizingPoint === point.id ? "z-50" : "z-30"}`}
               style={{
                 left: `${point.x}%`,
                 top: `${point.y}%`,

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -1251,7 +1251,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
     showCollisionNotification,
   ]);
 
-  // Função para calcular distância toroidal correta
+  // Fun��ão para calcular distância toroidal correta
   const getToroidalDistance = (
     pos1: { x: number; y: number },
     pos2: { x: number; y: number },
@@ -2651,7 +2651,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
               key={point.id}
               className={`absolute transform -translate-x-1/2 -translate-y-1/2 ${
                 isAdmin
-                  ? isCtrlPressed || resizingPoint === point.id
+                  ? resizingPoint === point.id
                     ? "cursor-crosshair"
                     : "cursor-grab hover:cursor-grab active:cursor-grabbing"
                   : "cursor-pointer"

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -2961,7 +2961,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
               </span>
             </div>
             <div className="text-xs text-blue-100 mt-1">
-              Solte Ctrl ou clique fora para sair
+              Solte Ctrl ou pressione Esc para sair
             </div>
           </motion.div>
         </div>

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -1375,16 +1375,8 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
       return;
     }
 
-    // Sair do modo de redimensionamento ao tocar no canvas
-    if (resizingPoint !== null) {
-      setResizingPoint(null);
-      setResizeStartScale(1);
-      setResizeStartY(0);
-      return;
-    }
-
-    // Não inicia drag do mapa se estiver arrastando um ponto
-    if (draggingPoint !== null) return;
+    // Não inicia drag do mapa se estiver arrastando um ponto ou redimensionando
+    if (draggingPoint !== null || resizingPoint !== null) return;
 
     const touch = e.touches[0];
     if (!touch) return;
@@ -1538,7 +1530,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
       WORLD_CONFIG.height,
     );
 
-    // Sistema de detecção de colisão
+    // Sistema de detecç��o de colisão
     const collision = checkCollisionWithBarriers(proposedX, proposedY);
     const allowMovement = !collision.isColliding;
 

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -2927,6 +2927,28 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
         )}
       </AnimatePresence>
 
+      {/* Notificação do modo de redimensionamento ativo */}
+      {resizingPoint !== null && (
+        <div className="absolute top-4 left-1/2 transform -translate-x-1/2 z-50">
+          <motion.div
+            className="bg-blue-600 text-white px-4 py-2 rounded-lg shadow-lg border border-blue-400"
+            initial={{ opacity: 0, y: -20, scale: 0.9 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: -20, scale: 0.9 }}
+          >
+            <div className="flex items-center space-x-2">
+              <div className="w-2 h-2 bg-white rounded-full animate-pulse"></div>
+              <span className="text-sm font-medium">
+                🔧 Modo Redimensionar Ativo
+              </span>
+            </div>
+            <div className="text-xs text-blue-100 mt-1">
+              Solte Ctrl ou clique fora para sair
+            </div>
+          </motion.div>
+        </div>
+      )}
+
       {/* Coordenadas simplificadas na parte inferior */}
       <div className="absolute bottom-4 left-1/2 transform -translate-x-1/2 text-white/20 text-xs font-mono font-thin whitespace-nowrap">
         X: {mapX.get().toFixed(1)} Y: {mapY.get().toFixed(1)}

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -2355,7 +2355,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
       isCtrlPressed,
       pointId: point.id,
     });
-    if (e.ctrlKey || isCtrlPressed) {
+    if (e.ctrlKey) {
       console.log(
         "🔧 Ativando modo de redimensionamento para ponto:",
         point.id,

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -895,56 +895,10 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
     resizingPointRef.current = resizingPoint;
   }, [resizingPoint]);
 
-  // Controle da tecla Ctrl para modo de redimensionamento
+  // Tecla Esc para sair do modo de redimensionamento
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      console.log(
-        "🔧 handleKeyDown:",
-        e.key,
-        "ctrlKey:",
-        e.ctrlKey,
-        "current isCtrlPressed:",
-        isCtrlPressedRef.current,
-      );
-      if (e.key === "Control" || e.ctrlKey) {
-        console.log("🔧 Setting isCtrlPressed to true");
-        setIsCtrlPressed(true);
-      }
-      // Tecla Esc para sair do modo de redimensionamento
       if (e.key === "Escape" && resizingPointRef.current !== null) {
-        console.log("🔧 Esc pressed, exiting resize mode");
-        setResizingPoint(null);
-        setResizeStartScale(1);
-        setResizeStartY(0);
-      }
-    };
-
-    const handleKeyUp = (e: KeyboardEvent) => {
-      console.log(
-        "🔧 handleKeyUp:",
-        e.key,
-        "ctrlKey:",
-        e.ctrlKey,
-        "current resizingPoint:",
-        resizingPointRef.current,
-      );
-      if (e.key === "Control" || !e.ctrlKey) {
-        console.log("🔧 Setting isCtrlPressed to false");
-        setIsCtrlPressed(false);
-        // Sair do modo de redimensionamento quando Ctrl for solto
-        if (resizingPointRef.current !== null) {
-          console.log("🔧 Ctrl released, exiting resize mode");
-          setResizingPoint(null);
-          setResizeStartScale(1);
-          setResizeStartY(0);
-        }
-      }
-    };
-
-    // Também detecta quando a janela perde foco (Alt+Tab, etc)
-    const handleWindowBlur = () => {
-      setIsCtrlPressed(false);
-      if (resizingPointRef.current !== null) {
         setResizingPoint(null);
         setResizeStartScale(1);
         setResizeStartY(0);
@@ -952,14 +906,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
     };
 
     document.addEventListener("keydown", handleKeyDown);
-    document.addEventListener("keyup", handleKeyUp);
-    window.addEventListener("blur", handleWindowBlur);
-
-    return () => {
-      document.removeEventListener("keydown", handleKeyDown);
-      document.removeEventListener("keyup", handleKeyUp);
-      window.removeEventListener("blur", handleWindowBlur);
-    };
+    return () => document.removeEventListener("keydown", handleKeyDown);
   }, []);
 
   // Função para repelir o jogador
@@ -2958,7 +2905,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
                         Área de Interação
                       </p>
                       <p className="text-xs text-gray-500">
-                        Comércio • Missões • Informações
+                        Comércio • Missões ��� Informações
                       </p>
                     </div>
                   </div>

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -233,6 +233,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
   const [resizingPoint, setResizingPoint] = useState<number | null>(null);
   const [resizeStartScale, setResizeStartScale] = useState<number>(1);
   const [resizeStartY, setResizeStartY] = useState<number>(0);
+  const [isCtrlPressed, setIsCtrlPressed] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
   const [isColliding, setIsColliding] = useState(false);
   const [collisionNotification, setCollisionNotification] = useState<{

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -933,7 +933,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
       document.removeEventListener("keyup", handleKeyUp);
       window.removeEventListener("blur", handleWindowBlur);
     };
-  }, [resizingPoint]);
+  }, []);
 
   // Função para repelir o jogador
   const repelPlayer = useCallback(
@@ -2790,7 +2790,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
                   )}
                   {isAdmin && (
                     <div className="text-yellow-400 text-xs mt-1">
-                      <div>⚡ Arraste para mover</div>
+                      <div>�� Arraste para mover</div>
                       <div>🔧 Ctrl+Arraste para redimensionar</div>
                     </div>
                   )}

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -892,12 +892,14 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === "Control" || e.ctrlKey) {
+        console.log("🔧 Ctrl pressionado, ativando modo redimensionar");
         setIsCtrlPressed(true);
       }
     };
 
     const handleKeyUp = (e: KeyboardEvent) => {
       if (e.key === "Control" || !e.ctrlKey) {
+        console.log("🔧 Ctrl solto, desativando modo redimensionar");
         setIsCtrlPressed(false);
         // Sair do modo de redimensionamento quando Ctrl for solto
         if (resizingPoint !== null) {

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -178,7 +178,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
           } else {
             const defaultPoints = createDefaultPoints();
             setPoints(defaultPoints);
-            console.log("🎯 Usando pontos padrão");
+            console.log("��� Usando pontos padrão");
           }
         }
       } catch (error) {
@@ -894,10 +894,6 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
   useEffect(() => {
     resizingPointRef.current = resizingPoint;
   }, [resizingPoint]);
-
-  useEffect(() => {
-    isCtrlPressedRef.current = isCtrlPressed;
-  }, [isCtrlPressed]);
 
   // Controle da tecla Ctrl para modo de redimensionamento
   useEffect(() => {

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -276,7 +276,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
   const mapRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  // Motion values para posição do mapa (movimento inverso da nave)
+  // Motion values para posi��ão do mapa (movimento inverso da nave)
   const getInitialMapPosition = () => {
     const saved = localStorage.getItem("xenopets-player-data");
     const data = saved
@@ -2311,7 +2311,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
     e.stopPropagation();
 
     // Check if holding Ctrl for resize mode
-    if (e.ctrlKey) {
+    if (e.ctrlKey || isCtrlPressed) {
       setResizingPoint(point.id);
       setResizeStartScale(point.scale || 1);
       setResizeStartY(e.clientY);

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -1790,6 +1790,15 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
         return;
       }
 
+      // Handle point rotation end
+      if (isAdmin && rotatingPoint !== null) {
+        await savePoints(points);
+        setRotatingPoint(null);
+        setRotateStartRotation(0);
+        setRotateStartAngle(0);
+        return;
+      }
+
       // Handle point dragging end
       if (isAdmin && draggingPoint !== null) {
         await savePoints(points);

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -908,7 +908,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
         setIsCtrlPressed(true);
       }
       // Tecla Esc para sair do modo de redimensionamento
-      if (e.key === "Escape" && resizingPoint !== null) {
+      if (e.key === "Escape" && resizingPointRef.current !== null) {
         setResizingPoint(null);
         setResizeStartScale(1);
         setResizeStartY(0);
@@ -919,7 +919,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
       if (e.key === "Control" || !e.ctrlKey) {
         setIsCtrlPressed(false);
         // Sair do modo de redimensionamento quando Ctrl for solto
-        if (resizingPoint !== null) {
+        if (resizingPointRef.current !== null) {
           setResizingPoint(null);
           setResizeStartScale(1);
           setResizeStartY(0);
@@ -930,7 +930,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
     // Também detecta quando a janela perde foco (Alt+Tab, etc)
     const handleWindowBlur = () => {
       setIsCtrlPressed(false);
-      if (resizingPoint !== null) {
+      if (resizingPointRef.current !== null) {
         setResizingPoint(null);
         setResizeStartScale(1);
         setResizeStartY(0);
@@ -1547,7 +1547,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
       WORLD_CONFIG.height,
     );
 
-    // Sistema de detecç���o de colisão
+    // Sistema de detecç��o de colisão
     const collision = checkCollisionWithBarriers(proposedX, proposedY);
     const allowMovement = !collision.isColliding;
 


### PR DESCRIPTION
Add rotation functionality to galaxy map points with the following changes:

- Add optional `rotation` property to Point interface
- Include rotation value in galaxyWorldToPoint converter with default of 0
- Add rotation state management (rotatingPoint, rotateStartRotation, rotateStartAngle)
- Add rotation refs for accessing current state in event listeners
- Implement Alt+drag gesture to enter rotation mode for admin users
- Add mouse and touch event handlers for point rotation
- Apply rotation transform to point images using CSS transform
- Add Escape key handler to exit rotation mode
- Display rotation value in point tooltips when non-zero
- Add rotation mode notification UI with purple styling
- Update admin help text to include rotation instructions
- Prevent map dragging during rotation operations
- Save rotated points to storage after rotation ends

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/104424278caf4188a9c1471e0e4787ab/glow-field)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>104424278caf4188a9c1471e0e4787ab</projectId>-->
<!--<branchName>glow-field</branchName>-->