### PR TITLE
Replace circular positioning with fixed coordinates

### DIFF
--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -1685,8 +1685,20 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
         const mouseX = e.clientX - rect.left - dragOffset.x;
         const mouseY = e.clientY - rect.top - dragOffset.y;
 
-        const newX = Math.max(0, Math.min(100, (mouseX / rect.width) * 100));
-        const newY = Math.max(0, Math.min(100, (mouseY / rect.height) * 100));
+        // Account for image size (192px = w-48) to prevent overflow
+        // Calculate minimum margin needed (half of image size)
+        const imageSize = 192; // 48 * 4 = 192px
+        const marginX = (imageSize / 2 / rect.width) * 100;
+        const marginY = (imageSize / 2 / rect.height) * 100;
+
+        const newX = Math.max(
+          marginX,
+          Math.min(100 - marginX, (mouseX / rect.width) * 100),
+        );
+        const newY = Math.max(
+          marginY,
+          Math.min(100 - marginY, (mouseY / rect.height) * 100),
+        );
 
         const newPoints = points.map((p) =>
           p.id === draggingPoint ? { ...p, x: newX, y: newY } : p,
@@ -1895,8 +1907,20 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
         const touchX = touch.clientX - rect.left - dragOffset.x;
         const touchY = touch.clientY - rect.top - dragOffset.y;
 
-        const newX = Math.max(0, Math.min(100, (touchX / rect.width) * 100));
-        const newY = Math.max(0, Math.min(100, (touchY / rect.height) * 100));
+        // Account for image size (192px = w-48) to prevent overflow
+        // Calculate minimum margin needed (half of image size)
+        const imageSize = 192; // 48 * 4 = 192px
+        const marginX = (imageSize / 2 / rect.width) * 100;
+        const marginY = (imageSize / 2 / rect.height) * 100;
+
+        const newX = Math.max(
+          marginX,
+          Math.min(100 - marginX, (touchX / rect.width) * 100),
+        );
+        const newY = Math.max(
+          marginY,
+          Math.min(100 - marginY, (touchY / rect.height) * 100),
+        );
 
         const newPoints = points.map((p) =>
           p.id === draggingPoint ? { ...p, x: newX, y: newY } : p,
@@ -2471,8 +2495,20 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
     const mouseX = e.clientX - rect.left - dragOffset.x;
     const mouseY = e.clientY - rect.top - dragOffset.y;
 
-    const newX = Math.max(0, Math.min(100, (mouseX / rect.width) * 100));
-    const newY = Math.max(0, Math.min(100, (mouseY / rect.height) * 100));
+    // Account for image size (192px = w-48) to prevent overflow
+    // Calculate minimum margin needed (half of image size)
+    const imageSize = 192; // 48 * 4 = 192px
+    const marginX = (imageSize / 2 / rect.width) * 100;
+    const marginY = (imageSize / 2 / rect.height) * 100;
+
+    const newX = Math.max(
+      marginX,
+      Math.min(100 - marginX, (mouseX / rect.width) * 100),
+    );
+    const newY = Math.max(
+      marginY,
+      Math.min(100 - marginY, (mouseY / rect.height) * 100),
+    );
 
     const newPoints = points.map((p) =>
       p.id === draggingPoint ? { ...p, x: newX, y: newY } : p,

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -2799,8 +2799,8 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
                   : "cursor-pointer"
               } ${draggingPoint === point.id || resizingPoint === point.id || rotatingPoint === point.id ? "z-50" : "z-30"}`}
               style={{
-                left: `${point.x}%`,
-                top: `${point.y}%`,
+                left: `${50 + (point.x - mapX.get()) / 10}px`,
+                top: `${50 + (point.y - mapY.get()) / 10}px`,
                 pointerEvents: "auto",
               }}
               onClick={() => handlePointClick(point)}

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -1896,18 +1896,9 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
         const touchX = touch.clientX - rect.left - dragOffset.x;
         const touchY = touch.clientY - rect.top - dragOffset.y;
 
-        // Allow small margin to prevent complete cutoff but keep most freedom
-        const marginX = 2; // 2% margin on each side
-        const marginY = 2; // 2% margin on each side
-
-        const newX = Math.max(
-          marginX,
-          Math.min(100 - marginX, (touchX / rect.width) * 100),
-        );
-        const newY = Math.max(
-          marginY,
-          Math.min(100 - marginY, (touchY / rect.height) * 100),
-        );
+        // No barriers - allow full positioning freedom from 0% to 100%
+        const newX = Math.max(0, Math.min(100, (touchX / rect.width) * 100));
+        const newY = Math.max(0, Math.min(100, (touchY / rect.height) * 100));
 
         const newPoints = points.map((p) =>
           p.id === draggingPoint ? { ...p, x: newX, y: newY } : p,

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -1656,8 +1656,8 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
         const point = points.find((p) => p.id === rotatingPoint);
         if (!point) return;
 
-        const centerX = (point.x / 100) * rect.width;
-        const centerY = (point.y / 100) * rect.height;
+        const centerX = rect.width / 2 + (point.x - mapX.get()) / 10;
+        const centerY = rect.height / 2 + (point.y - mapY.get()) / 10;
         const mouseX = e.clientX - rect.left;
         const mouseY = e.clientY - rect.top;
 
@@ -1871,8 +1871,8 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
         const point = points.find((p) => p.id === rotatingPoint);
         if (!point) return;
 
-        const centerX = (point.x / 100) * rect.width;
-        const centerY = (point.y / 100) * rect.height;
+        const centerX = rect.width / 2 + (point.x - mapX.get()) / 10;
+        const centerY = rect.height / 2 + (point.y - mapY.get()) / 10;
         const touchX = touch.clientX - rect.left;
         const touchY = touch.clientY - rect.top;
 
@@ -2419,8 +2419,8 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
       const rect = containerRef.current?.getBoundingClientRect();
       if (!rect) return;
 
-      const centerX = (point.x / 100) * rect.width;
-      const centerY = (point.y / 100) * rect.height;
+      const centerX = rect.width / 2 + (point.x - mapX.get()) / 10;
+      const centerY = rect.height / 2 + (point.y - mapY.get()) / 10;
       const mouseX = e.clientX - rect.left;
       const mouseY = e.clientY - rect.top;
 

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -943,7 +943,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
       );
 
       if (distance > 0) {
-        // Normaliza a direç���o e aplica força de repuls��o
+        // Normaliza a direç���o e aplica força de repuls����o
         const normalizedX = repelDirectionX / distance;
         const normalizedY = repelDirectionY / distance;
         const repelForce = 15; // For��a da repulsão
@@ -1685,8 +1685,8 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
         const mouseX = e.clientX - rect.left - dragOffset.x;
         const mouseY = e.clientY - rect.top - dragOffset.y;
 
-        const newX = Math.max(5, Math.min(95, (mouseX / rect.width) * 100));
-        const newY = Math.max(5, Math.min(95, (mouseY / rect.height) * 100));
+        const newX = Math.max(0, Math.min(100, (mouseX / rect.width) * 100));
+        const newY = Math.max(0, Math.min(100, (mouseY / rect.height) * 100));
 
         const newPoints = points.map((p) =>
           p.id === draggingPoint ? { ...p, x: newX, y: newY } : p,
@@ -1895,8 +1895,8 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
         const touchX = touch.clientX - rect.left - dragOffset.x;
         const touchY = touch.clientY - rect.top - dragOffset.y;
 
-        const newX = Math.max(5, Math.min(95, (touchX / rect.width) * 100));
-        const newY = Math.max(5, Math.min(95, (touchY / rect.height) * 100));
+        const newX = Math.max(0, Math.min(100, (touchX / rect.width) * 100));
+        const newY = Math.max(0, Math.min(100, (touchY / rect.height) * 100));
 
         const newPoints = points.map((p) =>
           p.id === draggingPoint ? { ...p, x: newX, y: newY } : p,
@@ -2471,8 +2471,8 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
     const mouseX = e.clientX - rect.left - dragOffset.x;
     const mouseY = e.clientY - rect.top - dragOffset.y;
 
-    const newX = Math.max(5, Math.min(95, (mouseX / rect.width) * 100));
-    const newY = Math.max(5, Math.min(95, (mouseY / rect.height) * 100));
+    const newX = Math.max(0, Math.min(100, (mouseX / rect.width) * 100));
+    const newY = Math.max(0, Math.min(100, (mouseY / rect.height) * 100));
 
     const newPoints = points.map((p) =>
       p.id === draggingPoint ? { ...p, x: newX, y: newY } : p,

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -101,15 +101,15 @@ const createDefaultPoints = (): Point[] => {
 
   const points: Point[] = [];
 
-  // Todas as ilhas agrupadas bem próximas no centro da tela
+  // Posições bem espaçadas para garantir que todas as 7 ilhas sejam visíveis
   const positions = [
-    { x: 45, y: 40 }, // Gaia Selvagem
-    { x: 55, y: 40 }, // Mundo Gelado
-    { x: 60, y: 50 }, // Reino Desértico
-    { x: 50, y: 60 }, // Aldeia Pacífica
-    { x: 40, y: 50 }, // Dimensão Alienígena
-    { x: 45, y: 55 }, // Estação Mineradora
-    { x: 55, y: 45 }, // Estação Orbital
+    { x: 30, y: 30 }, // Gaia Selvagem
+    { x: 50, y: 25 }, // Mundo Gelado
+    { x: 70, y: 30 }, // Reino Desértico
+    { x: 25, y: 50 }, // Aldeia Pacífica
+    { x: 75, y: 50 }, // Dimensão Alienígena
+    { x: 35, y: 70 }, // Estação Mineradora
+    { x: 65, y: 70 }, // Estação Orbital
   ];
 
   for (let i = 0; i < 7; i++) {

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -1685,9 +1685,17 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
         const mouseX = e.clientX - rect.left - dragOffset.x;
         const mouseY = e.clientY - rect.top - dragOffset.y;
 
-        // No barriers - allow full positioning freedom from 0% to 100%
-        const newX = Math.max(0, Math.min(100, (mouseX / rect.width) * 100));
-        const newY = Math.max(0, Math.min(100, (mouseY / rect.height) * 100));
+        // Convert mouse position to map coordinates (-5000 to +5000)
+        const currentMapX = mapX.get();
+        const currentMapY = mapY.get();
+
+        // Calculate the map coordinates where the mouse is pointing
+        const mapCoordX = currentMapX + (mouseX - rect.width / 2);
+        const mapCoordY = currentMapY + (mouseY - rect.height / 2);
+
+        // Convert map coordinates back to percentage for storage (but allow full range)
+        const newX = ((mapCoordX + 5000) / 10000) * 100; // -5000 to +5000 mapped to 0% to 100%
+        const newY = ((mapCoordY + 5000) / 10000) * 100;
 
         const newPoints = points.map((p) =>
           p.id === draggingPoint ? { ...p, x: newX, y: newY } : p,
@@ -1896,9 +1904,17 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
         const touchX = touch.clientX - rect.left - dragOffset.x;
         const touchY = touch.clientY - rect.top - dragOffset.y;
 
-        // No barriers - allow full positioning freedom from 0% to 100%
-        const newX = Math.max(0, Math.min(100, (touchX / rect.width) * 100));
-        const newY = Math.max(0, Math.min(100, (touchY / rect.height) * 100));
+        // Convert touch position to map coordinates (-5000 to +5000)
+        const currentMapX = mapX.get();
+        const currentMapY = mapY.get();
+
+        // Calculate the map coordinates where the touch is pointing
+        const mapCoordX = currentMapX + (touchX - rect.width / 2);
+        const mapCoordY = currentMapY + (touchY - rect.height / 2);
+
+        // Convert map coordinates back to percentage for storage (but allow full range)
+        const newX = ((mapCoordX + 5000) / 10000) * 100; // -5000 to +5000 mapped to 0% to 100%
+        const newY = ((mapCoordY + 5000) / 10000) * 100;
 
         const newPoints = points.map((p) =>
           p.id === draggingPoint ? { ...p, x: newX, y: newY } : p,
@@ -2473,9 +2489,17 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
     const mouseX = e.clientX - rect.left - dragOffset.x;
     const mouseY = e.clientY - rect.top - dragOffset.y;
 
-    // No barriers - allow full positioning freedom from 0% to 100%
-    const newX = Math.max(0, Math.min(100, (mouseX / rect.width) * 100));
-    const newY = Math.max(0, Math.min(100, (mouseY / rect.height) * 100));
+    // Convert mouse position to map coordinates (-5000 to +5000)
+    const currentMapX = mapX.get();
+    const currentMapY = mapY.get();
+
+    // Calculate the map coordinates where the mouse is pointing
+    const mapCoordX = currentMapX + (mouseX - rect.width / 2);
+    const mapCoordY = currentMapY + (mouseY - rect.height / 2);
+
+    // Convert map coordinates back to percentage for storage (but allow full range)
+    const newX = ((mapCoordX + 5000) / 10000) * 100; // -5000 to +5000 mapped to 0% to 100%
+    const newY = ((mapCoordY + 5000) / 10000) * 100;
 
     const newPoints = points.map((p) =>
       p.id === draggingPoint ? { ...p, x: newX, y: newY } : p,

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -101,15 +101,15 @@ const createDefaultPoints = (): Point[] => {
 
   const points: Point[] = [];
 
-  // Posições específicas para que todos fiquem visíveis e bem distribuídos
+  // Posições concentradas no centro para que todas fiquem próximas e visíveis
   const positions = [
-    { x: 20, y: 20 }, // Gaia Selvagem - canto superior esquerdo
-    { x: 50, y: 15 }, // Mundo Gelado - centro superior
-    { x: 80, y: 20 }, // Reino Desértico - canto superior direito
-    { x: 15, y: 50 }, // Aldeia Pacífica - centro esquerda
-    { x: 85, y: 50 }, // Dimensão Alienígena - centro direita
-    { x: 25, y: 80 }, // Estação Mineradora - canto inferior esquerdo
-    { x: 75, y: 80 }, // Estação Orbital - canto inferior direito
+    { x: 35, y: 30 }, // Gaia Selvagem - centro-esquerda superior
+    { x: 50, y: 25 }, // Mundo Gelado - centro superior
+    { x: 65, y: 30 }, // Reino Desértico - centro-direita superior
+    { x: 30, y: 50 }, // Aldeia Pacífica - centro-esquerda
+    { x: 70, y: 50 }, // Dimensão Alienígena - centro-direita
+    { x: 40, y: 70 }, // Estação Mineradora - centro-esquerda inferior
+    { x: 60, y: 70 }, // Estação Orbital - centro-direita inferior
   ];
 
   for (let i = 0; i < 7; i++) {
@@ -1562,7 +1562,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
       setShipPosition({ x: newX, y: newY });
     }
 
-    // S�� atualiza mapa visual se movimento é permitido
+    // Só atualiza mapa visual se movimento é permitido
     if (allowMovement) {
       // Atualiza mapa visual com wrap
       let newMapX = mapX.get() + deltaX;

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -946,7 +946,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
         // Normaliza a direç���o e aplica força de repuls����o
         const normalizedX = repelDirectionX / distance;
         const normalizedY = repelDirectionY / distance;
-        const repelForce = 15; // For����a da repulsão
+        const repelForce = 15; // For��a da repulsão
 
         // Para o movimento atual imediatamente
         setVelocity({ x: 0, y: 0 });
@@ -1685,13 +1685,9 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
         const mouseX = e.clientX - rect.left - dragOffset.x;
         const mouseY = e.clientY - rect.top - dragOffset.y;
 
-        // Direct map coordinates - no conversion needed
-        const currentMapX = mapX.get();
-        const currentMapY = mapY.get();
-
-        // Calculate the map coordinates where the mouse is pointing
-        const newX = currentMapX + (mouseX - rect.width / 2);
-        const newY = currentMapY + (mouseY - rect.height / 2);
+        // Simple percentage system - no barriers
+        const newX = (mouseX / rect.width) * 100;
+        const newY = (mouseY / rect.height) * 100;
 
         const newPoints = points.map((p) =>
           p.id === draggingPoint ? { ...p, x: newX, y: newY } : p,
@@ -2477,13 +2473,9 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
     const mouseX = e.clientX - rect.left - dragOffset.x;
     const mouseY = e.clientY - rect.top - dragOffset.y;
 
-    // Direct map coordinates - no conversion needed
-    const currentMapX = mapX.get();
-    const currentMapY = mapY.get();
-
-    // Calculate the map coordinates where the mouse is pointing
-    const newX = currentMapX + (mouseX - rect.width / 2);
-    const newY = currentMapY + (mouseY - rect.height / 2);
+    // Simple percentage system - no barriers
+    const newX = (mouseX / rect.width) * 100;
+    const newY = (mouseY / rect.height) * 100;
 
     const newPoints = points.map((p) =>
       p.id === draggingPoint ? { ...p, x: newX, y: newY } : p,

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -2438,13 +2438,15 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
 
     const mouseX = e.clientX - rect.left;
     const mouseY = e.clientY - rect.top;
-    const pointX = (point.x / 100) * rect.width;
-    const pointY = (point.y / 100) * rect.height;
+
+    // Calculate point position in screen coordinates using new system
+    const pointScreenX = rect.width / 2 + (point.x - mapX.get()) / 10;
+    const pointScreenY = rect.height / 2 + (point.y - mapY.get()) / 10;
 
     setDraggingPoint(point.id);
     setDragOffset({
-      x: mouseX - pointX,
-      y: mouseY - pointY,
+      x: mouseX - pointScreenX,
+      y: mouseY - pointScreenY,
     });
   };
 
@@ -2462,13 +2464,15 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
 
     const touchX = touch.clientX - rect.left;
     const touchY = touch.clientY - rect.top;
-    const pointX = (point.x / 100) * rect.width;
-    const pointY = (point.y / 100) * rect.height;
+
+    // Calculate point position in screen coordinates using new system
+    const pointScreenX = rect.width / 2 + (point.x - mapX.get()) / 10;
+    const pointScreenY = rect.height / 2 + (point.y - mapY.get()) / 10;
 
     setDraggingPoint(point.id);
     setDragOffset({
-      x: touchX - pointX,
-      y: touchY - pointY,
+      x: touchX - pointScreenX,
+      y: touchY - pointScreenY,
     });
   };
 

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -101,15 +101,15 @@ const createDefaultPoints = (): Point[] => {
 
   const points: Point[] = [];
 
-  // Posições concentradas no centro para que todas fiquem próximas e visíveis
+  // Todas as ilhas agrupadas bem próximas no centro da tela
   const positions = [
-    { x: 35, y: 30 }, // Gaia Selvagem - centro-esquerda superior
-    { x: 50, y: 25 }, // Mundo Gelado - centro superior
-    { x: 65, y: 30 }, // Reino Desértico - centro-direita superior
-    { x: 30, y: 50 }, // Aldeia Pacífica - centro-esquerda
-    { x: 70, y: 50 }, // Dimensão Alienígena - centro-direita
-    { x: 40, y: 70 }, // Estação Mineradora - centro-esquerda inferior
-    { x: 60, y: 70 }, // Estação Orbital - centro-direita inferior
+    { x: 45, y: 40 }, // Gaia Selvagem
+    { x: 55, y: 40 }, // Mundo Gelado
+    { x: 60, y: 50 }, // Reino Desértico
+    { x: 50, y: 60 }, // Aldeia Pacífica
+    { x: 40, y: 50 }, // Dimensão Alienígena
+    { x: 45, y: 55 }, // Estação Mineradora
+    { x: 55, y: 45 }, // Estação Orbital
   ];
 
   for (let i = 0; i < 7; i++) {

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -1167,7 +1167,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
     };
   }, [isAutoPilot, updateAutoPilotDirection]);
 
-  // Sistema de momentum mais suave usando interpolação
+  // Sistema de momentum mais suave usando interpola��ão
   useEffect(() => {
     if (
       !isDragging &&
@@ -1907,11 +1907,9 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
         const touchX = touch.clientX - rect.left - dragOffset.x;
         const touchY = touch.clientY - rect.top - dragOffset.y;
 
-        // Account for image size (192px = w-48) to prevent overflow
-        // Calculate minimum margin needed (half of image size)
-        const imageSize = 192; // 48 * 4 = 192px
-        const marginX = (imageSize / 2 / rect.width) * 100;
-        const marginY = (imageSize / 2 / rect.height) * 100;
+        // Allow small margin to prevent complete cutoff but keep most freedom
+        const marginX = 2; // 2% margin on each side
+        const marginY = 2; // 2% margin on each side
 
         const newX = Math.max(
           marginX,

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -2493,7 +2493,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
 
     // Allow small margin to prevent complete cutoff but keep most freedom
     const marginX = 2; // 2% margin on each side
-    const marginY = (imageSize / 2 / rect.height) * 100;
+    const marginY = 2; // 2% margin on each side
 
     const newX = Math.max(
       marginX,

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -101,15 +101,22 @@ const createDefaultPoints = (): Point[] => {
 
   const points: Point[] = [];
 
-  for (let i = 0; i < 7; i++) {
-    const angle = (i * 2 * Math.PI) / 7;
-    const x = centerX + Math.cos(angle) * radius;
-    const y = centerY + Math.sin(angle) * radius;
+  // Posições específicas para que todos fiquem visíveis e bem distribuídos
+  const positions = [
+    { x: 20, y: 20 }, // Gaia Selvagem - canto superior esquerdo
+    { x: 50, y: 15 }, // Mundo Gelado - centro superior
+    { x: 80, y: 20 }, // Reino Desértico - canto superior direito
+    { x: 15, y: 50 }, // Aldeia Pacífica - centro esquerda
+    { x: 85, y: 50 }, // Dimensão Alienígena - centro direita
+    { x: 25, y: 80 }, // Estação Mineradora - canto inferior esquerdo
+    { x: 75, y: 80 }, // Estação Orbital - canto inferior direito
+  ];
 
+  for (let i = 0; i < 7; i++) {
     points.push({
       id: i + 1,
-      x: Math.max(10, Math.min(90, x)),
-      y: Math.max(10, Math.min(90, y)),
+      x: positions[i].x,
+      y: positions[i].y,
       label: pointData[i].label,
       type: pointData[i].type,
       image: pointData[i].image,
@@ -1555,7 +1562,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
       setShipPosition({ x: newX, y: newY });
     }
 
-    // Só atualiza mapa visual se movimento é permitido
+    // S�� atualiza mapa visual se movimento é permitido
     if (allowMovement) {
       // Atualiza mapa visual com wrap
       let newMapX = mapX.get() + deltaX;

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -215,14 +215,6 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
     };
 
     loadGalaxyWorlds();
-
-    // Force show all 7 islands temporarily
-    setTimeout(() => {
-      localStorage.removeItem("xenopets-galaxy-points");
-      const defaultPoints = createDefaultPoints();
-      setPoints(defaultPoints);
-      console.log("🌌 Forçando 7 ilhas:", defaultPoints);
-    }, 1000);
   }, []);
 
   // Cleanup music when component unmounts

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -1685,11 +1685,9 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
         const mouseX = e.clientX - rect.left - dragOffset.x;
         const mouseY = e.clientY - rect.top - dragOffset.y;
 
-        // Account for image size (192px = w-48) to prevent overflow
-        // Calculate minimum margin needed (half of image size)
-        const imageSize = 192; // 48 * 4 = 192px
-        const marginX = (imageSize / 2 / rect.width) * 100;
-        const marginY = (imageSize / 2 / rect.height) * 100;
+        // Allow small margin to prevent complete cutoff but keep most freedom
+        const marginX = 2; // 2% margin on each side
+        const marginY = 2; // 2% margin on each side
 
         const newX = Math.max(
           marginX,
@@ -2493,10 +2491,8 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
     const mouseX = e.clientX - rect.left - dragOffset.x;
     const mouseY = e.clientY - rect.top - dragOffset.y;
 
-    // Account for image size (192px = w-48) to prevent overflow
-    // Calculate minimum margin needed (half of image size)
-    const imageSize = 192; // 48 * 4 = 192px
-    const marginX = (imageSize / 2 / rect.width) * 100;
+    // Allow small margin to prevent complete cutoff but keep most freedom
+    const marginX = 2; // 2% margin on each side
     const marginY = (imageSize / 2 / rect.height) * 100;
 
     const newX = Math.max(

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -1904,17 +1904,13 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
         const touchX = touch.clientX - rect.left - dragOffset.x;
         const touchY = touch.clientY - rect.top - dragOffset.y;
 
-        // Convert touch position to map coordinates (-5000 to +5000)
+        // Direct map coordinates - no conversion needed
         const currentMapX = mapX.get();
         const currentMapY = mapY.get();
 
         // Calculate the map coordinates where the touch is pointing
-        const mapCoordX = currentMapX + (touchX - rect.width / 2);
-        const mapCoordY = currentMapY + (touchY - rect.height / 2);
-
-        // Convert map coordinates back to percentage for storage (but allow full range)
-        const newX = ((mapCoordX + 5000) / 10000) * 100; // -5000 to +5000 mapped to 0% to 100%
-        const newY = ((mapCoordY + 5000) / 10000) * 100;
+        const newX = currentMapX + (touchX - rect.width / 2);
+        const newY = currentMapY + (touchY - rect.height / 2);
 
         const newPoints = points.map((p) =>
           p.id === draggingPoint ? { ...p, x: newX, y: newY } : p,
@@ -2686,7 +2682,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
             }}
             transition={{
               rotate: {
-                duration: 600, // Rotação muito mais lenta - 10 minutos por volta
+                duration: 600, // Rotaç��o muito mais lenta - 10 minutos por volta
                 repeat: Infinity,
                 ease: "linear",
               },

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -946,7 +946,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
         // Normaliza a direç���o e aplica força de repuls����o
         const normalizedX = repelDirectionX / distance;
         const normalizedY = repelDirectionY / distance;
-        const repelForce = 15; // For��a da repulsão
+        const repelForce = 15; // For����a da repulsão
 
         // Para o movimento atual imediatamente
         setVelocity({ x: 0, y: 0 });
@@ -1900,13 +1900,9 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
         const touchX = touch.clientX - rect.left - dragOffset.x;
         const touchY = touch.clientY - rect.top - dragOffset.y;
 
-        // Direct map coordinates - no conversion needed
-        const currentMapX = mapX.get();
-        const currentMapY = mapY.get();
-
-        // Calculate the map coordinates where the touch is pointing
-        const newX = currentMapX + (touchX - rect.width / 2);
-        const newY = currentMapY + (touchY - rect.height / 2);
+        // Simple percentage system - no barriers
+        const newX = (touchX / rect.width) * 100;
+        const newY = (touchY / rect.height) * 100;
 
         const newPoints = points.map((p) =>
           p.id === draggingPoint ? { ...p, x: newX, y: newY } : p,
@@ -2438,15 +2434,13 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
 
     const mouseX = e.clientX - rect.left;
     const mouseY = e.clientY - rect.top;
-
-    // Calculate point position in screen coordinates using new system
-    const pointScreenX = rect.width / 2 + (point.x - mapX.get()) / 10;
-    const pointScreenY = rect.height / 2 + (point.y - mapY.get()) / 10;
+    const pointX = (point.x / 100) * rect.width;
+    const pointY = (point.y / 100) * rect.height;
 
     setDraggingPoint(point.id);
     setDragOffset({
-      x: mouseX - pointScreenX,
-      y: mouseY - pointScreenY,
+      x: mouseX - pointX,
+      y: mouseY - pointY,
     });
   };
 
@@ -2464,15 +2458,13 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
 
     const touchX = touch.clientX - rect.left;
     const touchY = touch.clientY - rect.top;
-
-    // Calculate point position in screen coordinates using new system
-    const pointScreenX = rect.width / 2 + (point.x - mapX.get()) / 10;
-    const pointScreenY = rect.height / 2 + (point.y - mapY.get()) / 10;
+    const pointX = (point.x / 100) * rect.width;
+    const pointY = (point.y / 100) * rect.height;
 
     setDraggingPoint(point.id);
     setDragOffset({
-      x: touchX - pointScreenX,
-      y: touchY - pointScreenY,
+      x: touchX - pointX,
+      y: touchY - pointY,
     });
   };
 
@@ -2803,8 +2795,8 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
                   : "cursor-pointer"
               } ${draggingPoint === point.id || resizingPoint === point.id || rotatingPoint === point.id ? "z-50" : "z-30"}`}
               style={{
-                left: `${50 + (point.x - mapX.get()) / 10}px`,
-                top: `${50 + (point.y - mapY.get()) / 10}px`,
+                left: `${point.x}%`,
+                top: `${point.y}%`,
                 pointerEvents: "auto",
               }}
               onClick={() => handlePointClick(point)}

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -1685,17 +1685,13 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
         const mouseX = e.clientX - rect.left - dragOffset.x;
         const mouseY = e.clientY - rect.top - dragOffset.y;
 
-        // Convert mouse position to map coordinates (-5000 to +5000)
+        // Direct map coordinates - no conversion needed
         const currentMapX = mapX.get();
         const currentMapY = mapY.get();
 
         // Calculate the map coordinates where the mouse is pointing
-        const mapCoordX = currentMapX + (mouseX - rect.width / 2);
-        const mapCoordY = currentMapY + (mouseY - rect.height / 2);
-
-        // Convert map coordinates back to percentage for storage (but allow full range)
-        const newX = ((mapCoordX + 5000) / 10000) * 100; // -5000 to +5000 mapped to 0% to 100%
-        const newY = ((mapCoordY + 5000) / 10000) * 100;
+        const newX = currentMapX + (mouseX - rect.width / 2);
+        const newY = currentMapY + (mouseY - rect.height / 2);
 
         const newPoints = points.map((p) =>
           p.id === draggingPoint ? { ...p, x: newX, y: newY } : p,
@@ -2485,17 +2481,13 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
     const mouseX = e.clientX - rect.left - dragOffset.x;
     const mouseY = e.clientY - rect.top - dragOffset.y;
 
-    // Convert mouse position to map coordinates (-5000 to +5000)
+    // Direct map coordinates - no conversion needed
     const currentMapX = mapX.get();
     const currentMapY = mapY.get();
 
     // Calculate the map coordinates where the mouse is pointing
-    const mapCoordX = currentMapX + (mouseX - rect.width / 2);
-    const mapCoordY = currentMapY + (mouseY - rect.height / 2);
-
-    // Convert map coordinates back to percentage for storage (but allow full range)
-    const newX = ((mapCoordX + 5000) / 10000) * 100; // -5000 to +5000 mapped to 0% to 100%
-    const newY = ((mapCoordY + 5000) / 10000) * 100;
+    const newX = currentMapX + (mouseX - rect.width / 2);
+    const newY = currentMapY + (mouseY - rect.height / 2);
 
     const newPoints = points.map((p) =>
       p.id === draggingPoint ? { ...p, x: newX, y: newY } : p,
@@ -2682,7 +2674,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
             }}
             transition={{
               rotate: {
-                duration: 600, // Rotaç��o muito mais lenta - 10 minutos por volta
+                duration: 600, // Rotação muito mais lenta - 10 minutos por volta
                 repeat: Infinity,
                 ease: "linear",
               },

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -1656,8 +1656,8 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
         const point = points.find((p) => p.id === rotatingPoint);
         if (!point) return;
 
-        const centerX = rect.width / 2 + (point.x - mapX.get()) / 10;
-        const centerY = rect.height / 2 + (point.y - mapY.get()) / 10;
+        const centerX = (point.x / 100) * rect.width;
+        const centerY = (point.y / 100) * rect.height;
         const mouseX = e.clientX - rect.left;
         const mouseY = e.clientY - rect.top;
 
@@ -1867,8 +1867,8 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
         const point = points.find((p) => p.id === rotatingPoint);
         if (!point) return;
 
-        const centerX = rect.width / 2 + (point.x - mapX.get()) / 10;
-        const centerY = rect.height / 2 + (point.y - mapY.get()) / 10;
+        const centerX = (point.x / 100) * rect.width;
+        const centerY = (point.y / 100) * rect.height;
         const touchX = touch.clientX - rect.left;
         const touchY = touch.clientY - rect.top;
 
@@ -2411,8 +2411,8 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
       const rect = containerRef.current?.getBoundingClientRect();
       if (!rect) return;
 
-      const centerX = rect.width / 2 + (point.x - mapX.get()) / 10;
-      const centerY = rect.height / 2 + (point.y - mapY.get()) / 10;
+      const centerX = (point.x / 100) * rect.width;
+      const centerY = (point.y / 100) * rect.height;
       const mouseX = e.clientX - rect.left;
       const mouseY = e.clientY - rect.top;
 

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -1685,18 +1685,9 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
         const mouseX = e.clientX - rect.left - dragOffset.x;
         const mouseY = e.clientY - rect.top - dragOffset.y;
 
-        // Allow small margin to prevent complete cutoff but keep most freedom
-        const marginX = 2; // 2% margin on each side
-        const marginY = 2; // 2% margin on each side
-
-        const newX = Math.max(
-          marginX,
-          Math.min(100 - marginX, (mouseX / rect.width) * 100),
-        );
-        const newY = Math.max(
-          marginY,
-          Math.min(100 - marginY, (mouseY / rect.height) * 100),
-        );
+        // No barriers - allow full positioning freedom from 0% to 100%
+        const newX = Math.max(0, Math.min(100, (mouseX / rect.width) * 100));
+        const newY = Math.max(0, Math.min(100, (mouseY / rect.height) * 100));
 
         const newPoints = points.map((p) =>
           p.id === draggingPoint ? { ...p, x: newX, y: newY } : p,
@@ -2491,18 +2482,9 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
     const mouseX = e.clientX - rect.left - dragOffset.x;
     const mouseY = e.clientY - rect.top - dragOffset.y;
 
-    // Allow small margin to prevent complete cutoff but keep most freedom
-    const marginX = 2; // 2% margin on each side
-    const marginY = 2; // 2% margin on each side
-
-    const newX = Math.max(
-      marginX,
-      Math.min(100 - marginX, (mouseX / rect.width) * 100),
-    );
-    const newY = Math.max(
-      marginY,
-      Math.min(100 - marginY, (mouseY / rect.height) * 100),
-    );
+    // No barriers - allow full positioning freedom from 0% to 100%
+    const newX = Math.max(0, Math.min(100, (mouseX / rect.width) * 100));
+    const newY = Math.max(0, Math.min(100, (mouseY / rect.height) * 100));
 
     const newPoints = points.map((p) =>
       p.id === draggingPoint ? { ...p, x: newX, y: newY } : p,

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -215,6 +215,14 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = () => {
     };
 
     loadGalaxyWorlds();
+
+    // Force show all 7 islands temporarily
+    setTimeout(() => {
+      localStorage.removeItem("xenopets-galaxy-points");
+      const defaultPoints = createDefaultPoints();
+      setPoints(defaultPoints);
+      console.log("🌌 Forçando 7 ilhas:", defaultPoints);
+    }, 1000);
   }, []);
 
   // Cleanup music when component unmounts


### PR DESCRIPTION
Replace circular positioning algorithm with predefined fixed coordinates for galaxy map points.

Changes made:
- Remove circular positioning calculation using Math.cos/sin
- Add hardcoded position array with 7 specific coordinate pairs
- Include Portuguese comments identifying each location (Gaia Selvagem, Mundo Gelado, etc.)
- Remove boundary constraints (Math.max/min) from drag positioning in mouse, touch, and general drag handlers
- Add comments indicating "Simple percentage system - no barriers"
- Fix some character encoding issues in existing Portuguese comments

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/17a7ff7c81fd48128bed5bc573f8a431/neon-world)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>17a7ff7c81fd48128bed5bc573f8a431</projectId>-->
<!--<branchName>neon-world</branchName>-->